### PR TITLE
fix: tutorial cardano-cli syntax to include era & debug fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,64 +6,55 @@ This starter kit shows how to execute common operations against the Cardano bloc
 
 For running this starter kit you'll need access to a fully synced instance of a Cardano Node and the `cardano-cli` binary.
 
-You don't want to install the required components yourself, you can use [Demeter.run](https://demeter.run) platform to create a cloud environment with access to common Cardano infrastrcuture. The following command will open this repo in a private, web-based VSCode IDE with access to a shared Cardano Node and a pre-installed binary of the `cardano-cli`.
+If you don't want to install the required components yourself, you can use the [Demeter.run](https://demeter.run) platform to create a cloud environment with access to common Cardano infrastructure. The following button will open this repo in a private, web-based VSCode IDE with access to a shared Cardano Node and a pre-installed binary of the `cardano-cli`.
 
 [![Code in Cardano Workspace](https://demeter.run/code/badge.svg)](https://demeter.run/code?repository=https://github.com/txpipe/cardano-cli-starter-kit.git&template=typescript)
 
 ## Navigating the Starter Kit
 
-This starter kit is organized as interactive documentation where you can try out the commands as you move along in each topic.
+This starter kit includes an interactive Jupyter notebook tutorial (`TUTORIAL.ipynb`) that walks you through:
+- Creating addresses and wallets
+- Building and submitting transactions
+- Minting native assets (tokens)
+
+Open `TUTORIAL.ipynb` in VSCode to get started with the step-by-step guide.
 
 ### Screen Layout
 
-The docs assume that you're reading this guide inside a Cardano Workspace, we recommend splitting your editor into two different panes, with the README on the left and the terminal on the right.
+We recommend splitting your editor into two panes: the tutorial notebook on the left and a terminal on the right.
 
 ![Split Screen Example](imgs/screenshot1.png)
 
-Whenever you see an example bash snippet as a step in any of the tutorials, you can copy & paste it into the embedded terminal on the right, this will give you inmediate and real feedback of each command.
+You can execute the code cells directly in the notebook, or copy commands into the terminal for immediate feedback.
 
 ### Cardano Node Access
 
-Since you're running this starter kit from a _Cardano Workspace_, you already have access to the required infrastrcuture, such as the Cardano Node. All the required binaries are pre-installed by default, including the `cardano-cli`.
+Since you're running this starter kit from a _Cardano Workspace_, you already have access to the required infrastructure, such as the Cardano Node. All the required binaries are pre-installed by default, including the `cardano-cli`.
 
-The network to which you're connected (mainnet, preview, preprod, etc) is defined by your project's configuration, selected at the moment of creating your environment.
+The network you're connected to (mainnet, preview, preprod, etc) is defined by your project's configuration, selected when creating your environment.
 
-To simplify the overall process, _Cardano Workspaces_ come already configured with specific environmental variables that allows you to connect to the node without extra step. These are the variables relevant for this particular tutorial:
+To simplify the process, _Cardano Workspaces_ come pre-configured with environment variables that allow you to connect to the node without extra steps. These are the variables relevant for this tutorial:
 
-- `CARDANO_NODE_SOCKET_PATH`: provides the location of the unix socket within the workspace where the cardano node is listening to.
-- `CARDANO_NODE_MAGIC`: the network magic corresponding to the node that is connected to the workspace.
+- `CARDANO_NODE_SOCKET_PATH`: the location of the unix socket where the Cardano node is listening
+- `CARDANO_NODE_MAGIC`: the network magic corresponding to the connected node
 
-To ensure that you're connected to the node, try running the following command which outputs the current tip of the node:
+To verify your connection to the node, run the following command to query the current tip:
 
 ```sh
 cardano-cli query tip --testnet-magic $CARDANO_NODE_MAGIC
 ```
 
-if everything worked correctly, you should see an output similar to this one:
+If everything works correctly, you should see output similar to this:
 
 ```json
 {
-    "block": 204803,
-    "epoch": 51,
-    "era": "Babbage",
-    "hash": "e2de3e03c45787e1f20609ed5f9a71098b0cb75e52abca459db34354cab29423",
-    "slot": 4454222,
+    "block": 4045465,
+    "epoch": 248,
+    "era": "Conway",
+    "hash": "f21698559c893bdd86a3e0b237515cef01c1b2283f16fc205bfe370e4b69feed",
+    "slot": 105641870,
+    "slotInEpoch": 147470,
+    "slotsToEpochEnd": 284530,
     "syncProgress": "100.00"
 }
 ```
-
-## Table of Contents
-
-The following list describes the different parts of the tutorial. We recommend following them in order since each one provides instructions and resources that might be required to execute later steps.
-
-### 1. [Account Management](./01-account-management.md)
-
-Explains how to create signing keys and addresses that represent your account while interacting with the blockchain.
-
-### 2. [Build Transactions](./02-build-transactions.md)
-
-Explains how to build a simple ADA transfer transaction and submit it onto the blockhain.
-
-### 3. [Mint Native Assets](./01-mint-native-assets.md)
-
-Explains how to mint custom native assets and transfer those assets to other addresses.

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "### Generate keys and address\n",
     "\n",
-    "If you already have a payment address and keys and you want to use those, you can skip this step. If not - we need to generate those to submit transactions and to send and receive ada or native assets. Payment verification and signing keys are the first keys we need to create."
+    "Generate a payment verification key and signing key. The verification key derives your address, while the signing key proves you own that address and allows you to spend funds from it."
    ]
   },
   {
@@ -38,12 +38,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Those two keys can now be used to generate an address."
+    "Build an address from the verification key."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -62,26 +62,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will save our address hash in a variable called address."
+    "Save the address to a variable for easy reference."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "my address is: addr_test1vzqf4qj8mj0d7ld9nfcu4s22rhnvx2f0psldjd5gm2z8j6gvqhvde\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "MY_ADDRESS=$(cat my_address.addr)\n",
     "\n",
@@ -95,9 +87,9 @@
    "source": [
     "### Fund the address\n",
     "\n",
-    "Submitting transactions always require you to pay a fee. Sending native assets requires also requires sending at least 1 ada. So make sure the address you are going to use as the input for the minting transaction has sufficient funds.\n",
+    "All Cardano transactions require fees paid in ADA. Request test funds from the [testnet faucet](https://docs.cardano.org/cardano-testnet/tools/faucet).\n",
     "\n",
-    "For the testnet, you can request funds through the [testnet faucet](https://docs.cardano.org/cardano-testnet/tools/faucet)."
+    "**Note:** 1 ADA = 1,000,000 lovelace. The CLI displays amounts in lovelace."
    ]
   },
   {
@@ -107,28 +99,18 @@
    "source": [
     "### Query address funds\n",
     "\n",
-    "Once we've finished requesting funds from the corresponding faucet, we can query the node to ensure that our address now displays the expected amount. For that, we execute the query utxo command using our recently generated address:"
+    "Verify that your address received funds from the faucet. This shows your UTxOs (Unspent Transaction Outputs) - the spendable funds at your address."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                           TxHash                                 TxIx        Amount\n",
-      "--------------------------------------------------------------------------------------\n",
-      "fed2616805689edada882eb02c1d70d70f02f12f280c0b3baf6c4c2289204f87     1        9949834279 lovelace + TxOutDatumNone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cardano-cli query utxo \\\n",
     "    --address $MY_ADDRESS \\\n",
@@ -142,7 +124,7 @@
    "source": [
     "## Build Transactions\n",
     "\n",
-    "In this tutorial, we'll attempt to create a simple transaction that transfer ADA from one address to another."
+    "Cardano transactions consume UTxOs (inputs) and create new UTxOs (outputs). Let's transfer ADA from one address to another."
    ]
   },
   {
@@ -150,17 +132,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Generate recipient address\n",
     "\n",
-    "### Generate Address for the Destinatary\n",
-    "\n",
-    "In part [01](./01-account-management.md) we created our own address and added some funds. Since the goal of this part is to transfer ADA, we'll need to do the same for the destinatary of the transfer.\n",
-    "\n",
-    "Run the key-gen command again, but output the keys to different files."
+    "Create a second address to receive the ADA transfer."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -178,12 +157,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Those two keys can now be used to generate an address."
+    "Build the recipient address."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -202,26 +181,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will save our address hash in a variable called address."
+    "Save the recipient address to a variable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "the address of the destinatary is: addr_test1vqw2eumfgg5clc9u8fdhg9g5fl7flalsladpyaz2hku2wugwru2st\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "OTHER_ADDRESS=$(cat other_address.addr)\n",
     "\n",
@@ -233,33 +204,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Build the transaction\n",
     "\n",
-    "### Build the Tx Payload\n",
-    "\n",
-    "Txs in Cardano are deterministic. An user building a Tx will need to provide all inputs, outputs, parameters, etc that describe the operation as a whole.\n",
-    "\n",
-    "Following the above, the 1st step required to build a Tx is to gather the data of the inputs. For this, lets query the UTxO of our address by running the following command:\n"
+    "Query your address to get the UTxO that will fund this transaction. A UTxO is identified by its transaction hash (TxHash) and index (TxIx)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                           TxHash                                 TxIx        Amount\n",
-      "--------------------------------------------------------------------------------------\n",
-      "fed2616805689edada882eb02c1d70d70f02f12f280c0b3baf6c4c2289204f87     1        9949834279 lovelace + TxOutDatumNone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cardano-cli query utxo \\\n",
     "    --address $MY_ADDRESS \\\n",
@@ -267,41 +225,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ ACTION REQUIRED:**\n",
+    "> \n",
+    "> Run the cell above to query your UTxO, then copy the values from YOUR output:\n",
+    "> - Copy the **TxHash** value (long hexadecimal string)\n",
+    "> - Copy the **TxIx** value (usually 0 or 1)\n",
+    "> - Paste these values into the next cell replacing \"insert TxHash here\" and \"insert TxIx here\""
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "Since we need each of those values in our transaction, we will store them individually in a corresponding variable.\n",
-    "\n",
-    "We also need to define how much we want to transfer. It needs to be less than the amount of available funds, also taking into account the fees for the transfer.\n",
-    "\n",
-    "Now we are ready to build the first transaction to calculate our fee and save it in a file called matx.raw. We will reference the variables in our transaction to improve readability because we saved almost all of the needed values in variables. This is what our transaction looks like:"
+    "Set the transaction inputs and outputs. The `transaction build` command automatically calculates fees and balances the transaction for you."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Estimated transaction fee: Lovelace 165721\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "MY_TX_HASH=\"insert TxHash here\"\n",
     "MY_TX_IX=\"insert TxIx here\"\n",
     "TRANSFER_AMOUNT=\"50000000\"\n",
     "\n",
-    "cardano-cli transaction build \\\n",
+    "cardano-cli latest transaction build \\\n",
     " --testnet-magic $CARDANO_NODE_MAGIC \\\n",
     " --tx-in $MY_TX_HASH#$MY_TX_IX \\\n",
     " --tx-out $OTHER_ADDRESS+$TRANSFER_AMOUNT \\\n",
@@ -314,65 +271,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "we can inspect the transaction to ensure that it has what we expect"
+    "Inspect the transaction details."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "auxiliary scripts: null\n",
-      "certificates: null\n",
-      "collateral inputs: []\n",
-      "era: Babbage\n",
-      "fee: 165721 Lovelace\n",
-      "inputs:\n",
-      "- fed2616805689edada882eb02c1d70d70f02f12f280c0b3baf6c4c2289204f87#1\n",
-      "metadata: null\n",
-      "mint: null\n",
-      "outputs:\n",
-      "- address: addr_test1vqw2eumfgg5clc9u8fdhg9g5fl7flalsladpyaz2hku2wugwru2st\n",
-      "  address era: Shelley\n",
-      "  amount:\n",
-      "    lovelace: 50000000\n",
-      "  datum: null\n",
-      "  network: Testnet\n",
-      "  payment credential key hash: 1cacf36942298fe0bc3a5b7415144ffc9ff7f0ff5a12744abdb8a771\n",
-      "  reference script: null\n",
-      "  stake reference: null\n",
-      "- address: addr_test1vzqf4qj8mj0d7ld9nfcu4s22rhnvx2f0psldjd5gm2z8j6gvqhvde\n",
-      "  address era: Shelley\n",
-      "  amount:\n",
-      "    lovelace: 9899668558\n",
-      "  datum: null\n",
-      "  network: Testnet\n",
-      "  payment credential key hash: 809a8247dc9edf7da59a71cac14a1de6c3292f0c3ed93688da847969\n",
-      "  reference script: null\n",
-      "  stake reference: null\n",
-      "reference inputs: []\n",
-      "required signers (payment key hashes needed for scripts): null\n",
-      "return collateral: null\n",
-      "total collateral: null\n",
-      "update proposal: null\n",
-      "validity range:\n",
-      "  lower bound: null\n",
-      "  upper bound: null\n",
-      "withdrawals: null\n",
-      "witnesses: []\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    " cardano-cli transaction view --tx-file transfer.raw"
+    " cardano-cli debug transaction view --tx-file transfer.raw"
    ]
   },
   {
@@ -380,34 +292,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Sign the Transaction\n",
+    "### Sign the transaction\n",
     "\n",
-    "Transactions need to be signed to prove the authenticity and ownership of the policy key."
+    "Transactions must be cryptographically signed to prove you control the address spending the funds. This prevents unauthorized spending."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1;39m{\n",
-      "  \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"Witnessed Tx BabbageEra\"\u001b[0m\u001b[1;39m,\n",
-      "  \u001b[0m\u001b[34;1m\"description\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"Ledger Cddl Format\"\u001b[0m\u001b[1;39m,\n",
-      "  \u001b[0m\u001b[34;1m\"cborHex\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"84a30081825820fed2616805689edada882eb02c1d70d70f02f12f280c0b3baf6c4c2289204f87010182a200581d601cacf36942298fe0bc3a5b7415144ffc9ff7f0ff5a12744abdb8a771011a02faf080a200581d60809a8247dc9edf7da59a71cac14a1de6c3292f0c3ed93688da847969011b000000024e10f44e021a00028759a10081825820d308a0c373ce6e915cab83bc913eec5ec74ef3ec055cad5f73d790e4f0b7903758400f34f8e64901752d330aa0aef64750ea39110d4545ed45efceb53e51bf080fc89b6d0a9084b433a8ec14a7a7e6ce76e89a8053e27bc956df0c89d02950f7970ef5f6\"\u001b[0m\u001b[1;39m\n",
-      "\u001b[1;39m}\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cardano-cli transaction sign  \\\n",
+    "cardano-cli latest transaction sign  \\\n",
     "    --signing-key-file my_address.skey  \\\n",
     "    --testnet-magic $CARDANO_NODE_MAGIC \\\n",
     "    --tx-body-file transfer.raw  \\\n",
@@ -421,31 +321,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Submit the transaction\n",
     "\n",
-    "### Submit the Transaction\n",
-    "\n",
-    "Now we are going to submit the transaction by running the following command:\n"
+    "Submit the signed transaction to the blockchain."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Transaction successfully submitted.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cardano-cli transaction submit \\\n",
+    "cardano-cli latest transaction submit \\\n",
     "    --tx-file transfer.signed \\\n",
     "    --testnet-magic $CARDANO_NODE_MAGIC"
    ]
@@ -455,28 +346,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congratulations, we have now successfully transfered some ADA. After a couple of seconds, we can check the output address"
+    "Verify the transfer by querying the recipient address."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                           TxHash                                 TxIx        Amount\n",
-      "--------------------------------------------------------------------------------------\n",
-      "62a8fc5d8870672fdac1fbbdd209553cdf4334153e67287b98678d6ccf6e00df     0        50000000 lovelace + TxOutDatumNone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cardano-cli query utxo \\\n",
     "    --address $OTHER_ADDRESS \\\n",
@@ -495,16 +376,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create Minting Keys\n",
+    "### Create minting keys\n",
     "\n",
-    "Policies are the defining factor under which tokens can be minted. Only those in possession of the policy keys can mint or burn tokens minted under this specific policy. We'll make a separate sub-directory in our work directory to keep everything policy-wise separated and more organized. For further reading, please check the official docs or the github page about multi-signature scripts.\n",
-    "\n",
-    "First of all, we — again — need some key pairs:"
+    "Generate keys for your minting policy. The policy defines who can mint or burn tokens - only holders of the policy keys can create or destroy tokens under this policy."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -522,28 +401,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Hash the Key\n",
+    "### Hash the key\n",
     "\n",
-    "We need to find the hash of the key we just generated, it will be used as data to create the policy script:"
+    "Generate the key hash needed for the policy script."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "my policy hash is 540b538069c3087556293192baf85a4040104404a265933a3fab4c41\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "POLICY_HASH=$(cardano-cli address key-hash --payment-verification-key-file asset_policy.vkey)\n",
     "\n",
@@ -555,43 +426,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create a Policy Script\n",
+    "### Create a policy script\n",
     "\n",
-    "We need to create a file that defines the policy verification key as a witness to sign the minting transaction. There are no further constraints such as token locking or requiring specific signatures to successfully submit a transaction with this minting policy.\n",
-    "\n",
-    "Create a new `policy.script` with the following json content, replacing the required values with the data gathered in the previous steps:\n",
-    "\n",
-    "```json\n",
-    "{\n",
-    "    \"keyHash\": \"<POLICY_HASH>\",\n",
-    "    \"type\": \"sig\"\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "> **Warning**\n",
-    "> make sure to replace the `<POLICY_HASH>` string with the value computed in the previous step."
+    "The policy script defines the rules for minting/burning tokens. This simple signature policy requires a signature from the policy key to mint or burn tokens."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1;39m{\n",
-      "  \u001b[0m\u001b[34;1m\"type\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"sig\"\u001b[0m\u001b[1;39m,\n",
-      "  \u001b[0m\u001b[34;1m\"keyHash\"\u001b[0m\u001b[1;39m: \u001b[0m\u001b[0;32m\"540b538069c3087556293192baf85a4040104404a265933a3fab4c41\"\u001b[0m\u001b[1;39m\n",
-      "\u001b[1;39m}\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "echo \"{\\\"type\\\": \\\"sig\\\", \\\"keyHash\\\" : \\\"$POLICY_HASH\\\" }\" > policy.script\n",
     "\n",
@@ -603,30 +451,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Compute the Policy Id\n",
+    "### Compute the policy ID\n",
     "\n",
-    "To mint the native assets, we need to generate the policy ID from the script file we created."
+    "The policy ID uniquely identifies your token policy."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "my policy id is eea157d949cf2d30f16484cb1891a123892667540a2392629ef8f059\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "POLICY_ID=$(cardano-cli transaction policyid --script-file policy.script)\n",
+    "POLICY_ID=$(cardano-cli latest transaction policyid --script-file policy.script)\n",
     "\n",
     "echo \"my policy id is $POLICY_ID\""
    ]
@@ -636,8 +476,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "The output gets persisted in the `POLICY_ID` variable as we need to reference it later on.\n"
+    "The policy ID is saved to the `POLICY_ID` variable for use in the minting transaction."
    ]
   },
   {
@@ -645,15 +484,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Define the token\n",
     "\n",
-    "### Define the Token to Mint\n",
+    "Set the token name (hex-encoded) and amount to mint.\n",
     "\n",
-    "We need to defined the name for our token and the amount that we want to mint. Use the following snippet to define the values to use in following steps:\n",
-    "\n",
-    "```\n",
-    "TOKEN_NAME=\"54657374746F6B656E\"\n",
-    "TOKEN_AMOUNT=\"10000000\"\n",
-    "```"
+    "**Note:** The token name \"54657374746f6b656e\" is the hex encoding of \"Testtoken\"."
    ]
   },
   {
@@ -661,59 +496,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Build the minting transaction\n",
     "\n",
-    "### Build the Tx\n",
-    "\n",
-    "As we saw in part [02](./02-build-transactions.md) of the tutorial, building a transaction requires knowledge of the available UTxO in the address. Use the following command to query our address:"
+    "Query your address to get the current UTxO."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                           TxHash                                 TxIx        Amount\n",
-      "--------------------------------------------------------------------------------------\n",
-      "62a8fc5d8870672fdac1fbbdd209553cdf4334153e67287b98678d6ccf6e00df     1        9899668558 lovelace + TxOutDatumNone\n"
-     ]
-    }
-   ],
-   "source": [
-    "cardano-cli query utxo \\\n",
-    "    --address $MY_ADDRESS \\\n",
-    "    --testnet-magic $CARDANO_NODE_MAGIC"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "> **Note**\n",
-    "> This is the same command we executed when we queried our funds earlier in the tutorial.\n"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Since we need each of those values in our transaction, we will store them individually in a corresponding variable."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -721,9 +511,22 @@
    },
    "outputs": [],
    "source": [
-    "TX_HASH=\"instert TxHash here\"\n",
-    "TX_IX=\"insert TxIx here\"\n",
-    "TX_AMOUNT=\"9899668558\""
+    "cardano-cli query utxo \\\n",
+    "    --address $MY_ADDRESS \\\n",
+    "    --testnet-magic $CARDANO_NODE_MAGIC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **⚠️ ACTION REQUIRED:**\n",
+    "> \n",
+    "> Run the cell above to query your UTxO, then copy the values from YOUR output:\n",
+    "> - Copy the **TxHash** value\n",
+    "> - Copy the **TxIx** value\n",
+    "> - Copy the **Amount** value (the number before \"lovelace\")\n",
+    "> - Paste these values into the next cell replacing the placeholder strings"
    ]
   },
   {
@@ -731,13 +534,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "Our transaction will require to pay fees. For simplicity (and because we're using test ADA), we'll just put a high number to ensure that we cover the required amount:\n"
+    "Set the transaction variables. You'll need the TxHash, TxIx, and Amount from the UTxO query above."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "TX_HASH=\"insert TxHash here\"\n",
+    "TX_IX=\"insert TxIx here\"\n",
+    "TX_AMOUNT=\"insert Amount here\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the transaction fee. When using `build-raw`, fees must be specified manually. Lets set a arbitrarily high fee which will easily cover the minimum transaction cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -753,13 +578,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "To balance the transaction, we need to know which will be the remaining amount of our UTxO once we pay the fees. For that, we calculate the value using the following command:\n"
+    "Calculate the remaining balance after fees. The transaction must be balanced - inputs must equal outputs plus fees."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -775,13 +599,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "We will reference the variables in our transaction to improve readability because we saved almost all of the needed values in variables. This is what our transaction looks like:\n"
+    "Build the minting transaction. This transaction includes a `--mint` flag that creates new tokens and adds them to your address."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -792,7 +615,7 @@
     "TOKEN_NAME=\"54657374746F6B656E\"\n",
     "TOKEN_AMOUNT=\"10000000\"\n",
     "\n",
-    "cardano-cli transaction build-raw \\\n",
+    "cardano-cli latest transaction build-raw \\\n",
     " --fee $FEE \\\n",
     " --tx-in $TX_HASH#$TX_IX \\\n",
     " --tx-out $MY_ADDRESS+$REMAINING+\"$TOKEN_AMOUNT $POLICY_ID.$TOKEN_NAME\" \\\n",
@@ -803,70 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "auxiliary scripts: null\n",
-      "certificates: null\n",
-      "collateral inputs: []\n",
-      "era: Babbage\n",
-      "fee: 200000 Lovelace\n",
-      "inputs:\n",
-      "- 62a8fc5d8870672fdac1fbbdd209553cdf4334153e67287b98678d6ccf6e00df#1\n",
-      "metadata: null\n",
-      "mint:\n",
-      "  policy eea157d949cf2d30f16484cb1891a123892667540a2392629ef8f059:\n",
-      "    asset 54657374746f6b656e (Testtoken): 10000000\n",
-      "outputs:\n",
-      "- address: addr_test1vzqf4qj8mj0d7ld9nfcu4s22rhnvx2f0psldjd5gm2z8j6gvqhvde\n",
-      "  address era: Shelley\n",
-      "  amount:\n",
-      "    lovelace: 9899468558\n",
-      "    policy eea157d949cf2d30f16484cb1891a123892667540a2392629ef8f059:\n",
-      "      asset 54657374746f6b656e (Testtoken): 10000000\n",
-      "  datum: null\n",
-      "  network: Testnet\n",
-      "  payment credential key hash: 809a8247dc9edf7da59a71cac14a1de6c3292f0c3ed93688da847969\n",
-      "  reference script: null\n",
-      "  stake reference: null\n",
-      "reference inputs: []\n",
-      "required signers (payment key hashes needed for scripts): null\n",
-      "return collateral: null\n",
-      "total collateral: null\n",
-      "update proposal: null\n",
-      "validity range:\n",
-      "  lower bound: null\n",
-      "  upper bound: null\n",
-      "withdrawals: null\n"
-     ]
-    }
-   ],
-   "source": [
-    "cardano-cli transaction view --tx-body-file mint.raw"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "### Sign the Transaction\n",
-    "\n",
-    "Transactions need to be signed to prove the authenticity and ownership of the policy key.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
@@ -874,7 +634,30 @@
    },
    "outputs": [],
    "source": [
-    "cardano-cli transaction sign  \\\n",
+    "cardano-cli debug transaction view --tx-body-file mint.raw"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sign the transaction\n",
+    "\n",
+    "Minting requires two signatures: your address key (to spend the UTxO) and the policy key (to authorize minting)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cardano-cli latest transaction sign  \\\n",
     "    --signing-key-file my_address.skey  \\\n",
     "    --signing-key-file asset_policy.skey  \\\n",
     "    --testnet-magic $CARDANO_NODE_MAGIC \\\n",
@@ -887,31 +670,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Submit the transaction\n",
     "\n",
-    "### Submit the Transaction\n",
-    "\n",
-    "Now we are going to submit the transaction, therefore minting our native assets:\n"
+    "Submit the transaction to mint your tokens."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Transaction successfully submitted.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cardano-cli transaction submit \\\n",
+    "cardano-cli latest transaction submit \\\n",
     "    --tx-file mint.signed \\\n",
     "    --testnet-magic $CARDANO_NODE_MAGIC"
    ]
@@ -921,28 +695,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congratulations, we have now successfully minted our own token. After a couple of seconds, we can check the output address"
+    "Verify your new tokens by querying your address."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                           TxHash                                 TxIx        Amount\n",
-      "--------------------------------------------------------------------------------------\n",
-      "05faf31b9626187861cf8f567c2ac92a8da525b05a8a9e013f56d41b3a65efed     0        9899468558 lovelace + 10000000 eea157d949cf2d30f16484cb1891a123892667540a2392629ef8f059.54657374746f6b656e + TxOutDatumNone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cardano-cli query utxo --address $MY_ADDRESS --testnet-magic $CARDANO_NODE_MAGIC"
    ]
@@ -952,7 +716,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After a few seconds, you should be able to see that your address holds the newly minted assets"
+    "Your address should now hold the newly minted tokens."
    ]
   }
  ],

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -1,6 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cardano CLI Tutorial\n",
+    "\n",
+    "This interactive tutorial teaches you how to use the Cardano CLI to interact directly with a Cardano node. You'll learn to:\n",
+    "- Create addresses and wallets\n",
+    "- Build and submit transactions\n",
+    "- Mint your own native tokens\n",
+    "\n",
+    "**Setup:** If you're using this starter kit through Demeter.run, the Cardano node and CLI are already set up for you - you're ready to go! Otherwise, ensure you have access to a Cardano node and the `cardano-cli` installed.\n",
+    "\n",
+    "**How to use this notebook:** Execute each code cell one by one (click the cell and press Shift+Enter or click the play button). Some commands query the blockchain and may take a few seconds to return results.\n",
+    "\n",
+    "Let's get started!"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -196,7 +214,7 @@
    "source": [
     "OTHER_ADDRESS=$(cat other_address.addr)\n",
     "\n",
-    "echo \"the address of the destinatary is: $OTHER_ADDRESS\""
+    "echo \"the address of the recipient is: $OTHER_ADDRESS\""
    ]
   },
   {
@@ -228,12 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **⚠️ ACTION REQUIRED:**\n",
-    "> \n",
-    "> Run the cell above to query your UTxO, then copy the values from YOUR output:\n",
-    "> - Copy the **TxHash** value (long hexadecimal string)\n",
-    "> - Copy the **TxIx** value (usually 0 or 1)\n",
-    "> - Paste these values into the next cell replacing \"insert TxHash here\" and \"insert TxIx here\""
+    "Copy the **TxHash** and **TxIx** values from the executed cell output above and paste them into the next cell, replacing the placeholder strings."
    ]
   },
   {
@@ -378,7 +391,7 @@
    "source": [
     "### Create minting keys\n",
     "\n",
-    "Generate keys for your minting policy. The policy defines who can mint or burn tokens - only holders of the policy keys can create or destroy tokens under this policy."
+    "Generate keys for your minting policy. The policy defines who can mint or burn tokens - only holders of the policy keys can mint or burn tokens under this policy."
    ]
   },
   {
@@ -484,18 +497,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define the token\n",
-    "\n",
-    "Set the token name (hex-encoded) and amount to mint.\n",
-    "\n",
-    "**Note:** The token name \"54657374746f6b656e\" is the hex encoding of \"Testtoken\"."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Build the minting transaction\n",
     "\n",
     "Query your address to get the current UTxO."
@@ -520,13 +521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **⚠️ ACTION REQUIRED:**\n",
-    "> \n",
-    "> Run the cell above to query your UTxO, then copy the values from YOUR output:\n",
-    "> - Copy the **TxHash** value\n",
-    "> - Copy the **TxIx** value\n",
-    "> - Copy the **Amount** value (the number before \"lovelace\")\n",
-    "> - Paste these values into the next cell replacing the placeholder strings"
+    "Copy the **TxHash**, **TxIx**, and **Amount** values from the executed cell output above and paste them into the next cell, replacing the placeholder strings."
    ]
   },
   {
@@ -557,7 +552,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set the transaction fee. When using `build-raw`, fees must be specified manually. Lets set a arbitrarily high fee which will easily cover the minimum transaction cost."
+    "Set the transaction fee. When using `build-raw`, fees must be specified manually. We'll set an arbitrarily high fee which will easily cover the minimum transaction cost."
    ]
   },
   {
@@ -599,7 +594,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Build the minting transaction. This transaction includes a `--mint` flag that creates new tokens and adds them to your address."
+    "Build the minting transaction. This transaction includes a `--mint` flag that creates new tokens and adds them to your address.\n",
+    "\n",
+    "**Note:** The `TOKEN_NAME` must be hex-encoded. The value \"54657374746f6b656e\" is the hex encoding of \"Testtoken\"."
    ]
   },
   {
@@ -716,7 +713,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Your address should now hold the newly minted tokens."
+    "Your address should now hold the newly minted tokens.\n",
+    "\n",
+    "**Reading the output:**\n",
+    "- **Lovelace**: Your remaining ADA balance\n",
+    "- **Token amount + policy.tokenName**: Your minted tokens in the format `{amount} {policyId}.{hexTokenName}`\n",
+    "- For example: `10000000 c7fd...eb18.54657374746f6b656e` means you have 10,000,000 units of your token\n",
+    "\n",
+    "The long hex string (`c7fd...`) is your policy ID, and `54657374746f6b656e` is the hex-encoded token name (\"Testtoken\")."
    ]
   }
  ],

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -297,7 +297,7 @@
    },
    "outputs": [],
    "source": [
-    " cardano-cli debug transaction view --tx-file transfer.raw"
+    "cardano-cli debug transaction view --tx-file transfer.raw"
    ]
   },
   {
@@ -596,7 +596,7 @@
    "source": [
     "Build the minting transaction. This transaction includes a `--mint` flag that creates new tokens and adds them to your address.\n",
     "\n",
-    "**Note:** The `TOKEN_NAME` must be hex-encoded. The value \"54657374746f6b656e\" is the hex encoding of \"Testtoken\"."
+    "**Note:** The `TOKEN_NAME` must be hex-encoded. The value \"54657374746f6b656E\" is the hex encoding of \"Testtoken\"."
    ]
   },
   {


### PR DESCRIPTION
## Why

This PR fixes the currently broken starter kit by updating the outdated `cardano-cli` syntax and does a minor touch-up to documentation in the tutorial notebook.

## Examples

### Old

```
cardano-cli transaction build 
     --testnet-magic $CARDANO_NODE_MAGIC 
     --tx-in $MY_TX_HASH#$MY_TX_IX
     ...
``` 
### New

```
cardano-cli **latest** transaction build
    --testnet-magic $CARDANO_NODE_MAGIC
    --tx-in $MY_TX_HASH#$MY_TX_IX
    ...
```

---

### Old

```
cardano-cli transaction view --tx-file transfer.raw
```

### New

```
cardano-cli **debug** transaction view --tx-file transfer.raw
```

## Dev Portal

I also plan to integrate the demeter workspace into the [developer portal](https://developers.cardano.org/docs/get-started/cardano-cli/basic-operations/get-started) (screenshot from WIP branch attached, which will be merged to main once the starter kit is functional again). I think that will be a pretty cool addition to the docs itself to lower friction and also drive more traffic to demeter.run

<img width="977" height="528" alt="demeter-cardano-cli" src="https://github.com/user-attachments/assets/21963642-683a-4028-a449-f4a90cbf6bc9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote and expanded onboarding and navigation into a notebook-centered workflow with step-by-step activities (address creation, transaction building, asset minting)
  * Added an interactive Jupyter tutorial and clearer editor layout recommendation (notebook left, terminal right)
  * Clarified platform/infrastructure wording, environment variable descriptions, and connection verification examples
  * Updated command examples and minting flow guidance; removed the long-form table of contents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->